### PR TITLE
Update version to 0.2.0 for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust"
 rust-version = "1.76"
-version = "0.1.0"
+version = "0.2.0"
 
 [workspace.dependencies]
 async-trait = { version = "0.1" }


### PR DESCRIPTION
Bumping this to make a release. Will then update up-streamer-rust to make use of the newest Zenoh and the newest vsomeip transports.