### PR TITLE
Fix streamer usecase source authority check

### DIFF
--- a/up-transport-vsomeip/src/determine_message_type.rs
+++ b/up-transport-vsomeip/src/determine_message_type.rs
@@ -33,31 +33,67 @@ pub fn determine_type(
         // determine if we're in the uStreamer use-case of capturing all point-to-point messages
         trace!("source_filter: {source_filter:?}");
         trace!("sink_filter: {sink_filter:?}");
+
+        // Log each condition separately to identify which one(s) are failing
+        let source_wildcard_authority = !source_filter.has_wildcard_authority();
+        trace!("source_non_wildcard_authority: {source_wildcard_authority}");
+
+        let source_wildcard_entity_type = source_filter.has_wildcard_entity_type();
+        trace!("source_wildcard_entity_type: {source_wildcard_entity_type}");
+
+        let source_wildcard_entity_instance = source_filter.has_wildcard_entity_instance();
+        trace!("source_wildcard_entity_instance: {source_wildcard_entity_instance}");
+
+        let source_wildcard_version = source_filter.has_wildcard_version();
+        trace!("source_wildcard_version: {source_wildcard_version}");
+
+        let source_wildcard_resource_id = source_filter.has_wildcard_resource_id();
+        trace!("source_wildcard_resource_id: {source_wildcard_resource_id}");
+
+        let sink_non_wildcard_authority = !sink_filter.has_wildcard_authority();
+        trace!("sink_non_wildcard_authority: {sink_non_wildcard_authority}");
+
+        let sink_wildcard_entity_type = sink_filter.has_wildcard_entity_type();
+        trace!("sink_wildcard_entity_type: {sink_wildcard_entity_type}");
+
+        let sink_wildcard_entity_instance = sink_filter.has_wildcard_entity_instance();
+        trace!("sink_wildcard_entity_instance: {sink_wildcard_entity_instance}");
+
+        let sink_wildcard_version = sink_filter.has_wildcard_version();
+        trace!("sink_wildcard_version: {sink_wildcard_version}");
+
+        let sink_wildcard_resource_id = sink_filter.has_wildcard_resource_id();
+        trace!("sink_wildcard_resource_id: {sink_wildcard_resource_id}");
+
         let streamer_use_case = {
-            source_filter.has_wildcard_authority()
-                && source_filter.has_wildcard_entity_type()
-                && source_filter.has_wildcard_entity_instance()
-                && source_filter.has_wildcard_version()
-                && source_filter.has_wildcard_resource_id()
-                && !sink_filter.has_wildcard_authority()
-                && sink_filter.has_wildcard_entity_type()
-                && sink_filter.has_wildcard_entity_instance()
-                && sink_filter.has_wildcard_version()
-                && sink_filter.has_wildcard_resource_id()
+            source_wildcard_authority
+                && source_wildcard_entity_type
+                && source_wildcard_entity_instance
+                && source_wildcard_version
+                && source_wildcard_resource_id
+                && sink_non_wildcard_authority
+                && sink_wildcard_entity_type
+                && sink_wildcard_entity_instance
+                && sink_wildcard_version
+                && sink_wildcard_resource_id
         };
+        trace!("streamer_use_case final result: {streamer_use_case}");
 
         if streamer_use_case {
+            trace!("Matched streamer use case - returning AllPointToPoint");
             return Ok(RegistrationType::AllPointToPoint);
         }
 
+        // Log which case we're falling through to
         if sink_filter.resource_id == 0 {
+            trace!("sink_filter.resource_id == 0 - returning Response");
             Ok(RegistrationType::Response)
         } else {
+            trace!("sink_filter.resource_id != 0 - returning Request");
             Ok(RegistrationType::Request)
         }
     } else {
+        trace!("No sink_filter provided - returning Publish");
         Ok(RegistrationType::Publish)
     }
 }
-
-// TODO: Add unit tests


### PR DESCRIPTION
## Summary
- Carry forward the functional change from source PR #42 to enforce non-wildcard source authority in streamer usecase classification.

## Provenance
- Source PR: https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust/pull/42
- Source commit: `3e277e835916b9428d8492ea1ae1383c5131bca6`
- The change was reapplied on this branch from the source patch.
- Commit author was reattributed on this branch to satisfy current Eclipse Contributor Agreement email requirements.

## Validation
- `source build/envsetup.sh highest && cargo clippy --all-targets -- -W warnings -D warnings`
- `source build/envsetup.sh highest && cargo test -- --test-threads 1` (first run hit known one-message `publisher_subscriber` flake, reran once per policy and passed)