### PR TITLE
Upgrade up-rust to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ keywords = ["uProtocol", "SDK", "vsomeip", "SOMEIP"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust"
-rust-version = "1.76"
+rust-version = "1.82"
 version = "0.4.1"
 
 [workspace.dependencies]
@@ -51,6 +51,6 @@ regex = { version = "1.10" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 tokio = { version = "1.35.1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "tracing"] }
-up-rust = { version = "0.5.0" }
+up-rust = { version = "0.9.0" }
 vsomeip-proc-macro = { version = "0.4.0", path = "vsomeip-proc-macro" }
 vsomeip-sys = { version = "0.4.0", path = "vsomeip-sys", default-features = false }


### PR DESCRIPTION
## Summary
- Upgrade `[workspace.dependencies].up-rust` from `0.5.0` to crates.io `0.9.0`.
- Align workspace `rust-version` from `1.76` to `1.82` because `up-rust 0.9.0` declares `rust_version = 1.82` on crates.io.
- No code-level compatibility adaptations were required for listener/filter URI validation, payload extraction strictness, or communication API usage; existing code/tests compiled and ran successfully.

## Crates.io Target Confirmation
- crates.io API endpoint `https://crates.io/api/v1/crates/up-rust` reports:
  - `max_version = 0.9.0`
  - `max_stable_version = 0.9.0`
  - `yanked = false`

## Lockfile Update
- Ran: `cargo update -p up-rust --precise 0.9.0`
- Local lockfile resolves `up-rust 0.9.0` after update.
- `Cargo.lock` is intentionally gitignored in this library workspace, so no lockfile diff is included in this PR.

## Validation
Commands run from repo root:

```bash
source build/envsetup.sh highest
cargo check --all-targets
cargo clippy --all-targets -- -W warnings -D warnings
cargo test -- --test-threads 1
```

Outcomes:
- `cargo check --all-targets`: pass
- `cargo clippy --all-targets -- -W warnings -D warnings`: pass
- `cargo test -- --test-threads 1`: first rerun cycle saw the known `publisher_subscriber` flaky one-message miss (86 sent / 85 received), then reran full serial suite once per project guidance and it passed.