### PR TITLE
Prepare 0.5.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust"
 rust-version = "1.82"
-version = "0.4.1"
+version = "0.5.0"
 
 [workspace.dependencies]
 async-trait = { version = "0.1" }
@@ -52,5 +52,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 tokio = { version = "1.35.1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "tracing"] }
 up-rust = { version = "0.9.0" }
-vsomeip-proc-macro = { version = "0.4.0", path = "vsomeip-proc-macro" }
-vsomeip-sys = { version = "0.4.0", path = "vsomeip-sys", default-features = false }
+vsomeip-proc-macro = { version = "0.5.0", path = "vsomeip-proc-macro" }
+vsomeip-sys = { version = "0.5.0", path = "vsomeip-sys", default-features = false }


### PR DESCRIPTION
## Summary

- bump the synchronized workspace version from 0.4.1 to 0.5.0
- update the internal vsomeip-proc-macro and vsomeip-sys requirements to 0.5.0
- retain up-rust 0.9.0 and Rust 1.82

## Why 0.5.0

up-transport-vsomeip exposes up-rust types and implements its UTransport trait. Moving the public dependency from pre-1.0 up-rust 0.3 to 0.9 is not patch-compatible for downstream consumers, so this is a semver-minor release rather than 0.4.2.

The three publishable crates remain synchronized because they inherit the workspace version and prior releases used the same coordinated model.

## Merge ordering

Depends on #49.

This PR may be reviewed concurrently with #49, but it must not merge until #49 is merged and its authentication-only Trusted Publishing smoke test succeeds. Merging this PR does not publish anything; the separate reviewed v0.5.0 tag push is the release action.

## Release notes

- up-rust compatibility moves from 0.3 to 0.9
- MSRV moves from Rust 1.76 to 1.82
- the release includes the listener/filter and streamer-use-case behavior currently on main

## Validation

- cargo metadata confirms all three publishable crates resolve to 0.5.0
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -W warnings -D warnings
- cargo test -- --test-threads 1
- package content lists inspected for all three crates
- cargo package --allow-dirty -p vsomeip-proc-macro
- cargo package --allow-dirty -p vsomeip-sys

The transport package cannot complete registry-only packaging until vsomeip-proc-macro 0.5.0 and vsomeip-sys 0.5.0 are visible on crates.io. The workflow in #49 publishes and waits for those versions before running the transport package verification.

## Review focus

Feedback is especially welcome on the 0.5.0 version choice, synchronized internal dependency requirements, and compatibility/MSRV notes.